### PR TITLE
Fix code scanning alert no. 1: Reflected cross-site scripting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.7",
+        "escape-html": "^1.0.3",
         "express": "^4.21.2",
         "supertest": "^7.0.0",
         "uuid": "^11.0.3"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
+        "@types/escape-html": "^1.0.4",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.1",
@@ -1085,6 +1087,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true
     },
     "node_modules/@types/express": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
+    "escape-html": "^1.0.3",
     "express": "^4.21.2",
     "supertest": "^7.0.0",
     "uuid": "^11.0.3",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
+    "@types/escape-html": "^1.0.4",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "supertest": "^7.0.0",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,5 +1,6 @@
 import { validate as uuidValidate } from 'uuid';
 import express, { Request, Response } from 'express';
+import escapeHtml from 'escape-html';
 const router = express.Router();
 
 router.get('/:id', (req: Request, res: Response) => {
@@ -10,7 +11,7 @@ router.get('/:id', (req: Request, res: Response) => {
     res.send(JSON.stringify({ error: "INVALID_UUID", message: "An invalid UUID was entered." }));
     return;
   }
-  res.send(JSON.stringify({ uuid: player }));
+  res.send(JSON.stringify({ uuid: escapeHtml(player) }));
 })
 
 module.exports = router;


### PR DESCRIPTION
Fixes [https://github.com/AxionSpire/api/security/code-scanning/1](https://github.com/AxionSpire/api/security/code-scanning/1)

To fix the problem, we need to ensure that the user input is properly sanitized before being included in the response. The best way to fix this issue is to use a library that provides HTML escaping functionality to prevent XSS attacks. In this case, we can use the `escape-html` library to sanitize the `player` variable before including it in the response.

1. Install the `escape-html` library.
2. Import the `escape-html` library in the `src/player.ts` file.
3. Use the `escape-html` function to sanitize the `player` variable before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
